### PR TITLE
Update Benchmark Parser Issue #7

### DIFF
--- a/template/internal/benches/parse.go
+++ b/template/internal/benches/parse.go
@@ -16,7 +16,7 @@ func ParseGoBenchmark(input string) (*BenchOutputGroup, error) {
 
 	// Remove surrounding lines from the benchmarks
 	i := slices.IndexFunc(lines, func(s string) bool {
-		return strings.HasPrefix(s, "BenchmarkPart")
+		return strings.Contains(s, "\t")
 	})
 	lines = lines[i : i+2]
 

--- a/template/internal/benches/parse.go
+++ b/template/internal/benches/parse.go
@@ -3,6 +3,7 @@ package benches
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -13,11 +14,11 @@ import (
 func ParseGoBenchmark(input string) (*BenchOutputGroup, error) {
 	lines := strings.Split(input, "\n")
 
-	// Remove the first 5 lines
-	lines = lines[4:]
-
-	// Remove the last 2 lines
-	lines = lines[:len(lines)-3]
+	// Remove surrounding lines from the benchmarks
+	i := slices.IndexFunc(lines, func(s string) bool {
+		return strings.HasPrefix(s, "BenchmarkPart")
+	})
+	lines = lines[i : i+2]
 
 	currentBenchmark := &BenchOutputGroup{}
 	for _, line := range lines {


### PR DESCRIPTION
PR would deal with the issue raised in Issue #7 

Makes use of `slices.IndexFunc` to identify the index of the first Benchmark output, and will update lines accordingly.

Have tested this on the machine that I am working on right now (Macbook) and it now outputs as expected.

I am able to test later on today on a Linux machine to check the output is still sane.